### PR TITLE
Ensure PDF read/write enabled in ImageMagick

### DIFF
--- a/goss.yml
+++ b/goss.yml
@@ -16,6 +16,10 @@ command:
     exit-status: 0
     stdout:
       - "6"
+  php -r "echo join(',', Imagick::queryFormats('PDF'));":
+    exit-status: 0
+    stdout:
+      - "PDF"
   sudo npm --version:
     exit-status: 0
   composer --version:
@@ -91,6 +95,10 @@ file:
   /home/php/.config:
     exists: true
     owner: php
+  /etc/ImageMagick-6/policy.xml:
+    exists: true
+    contains:
+      - "<policy domain=\"module\" rights=\"read|write\" pattern=\"PDF\" />"
 
 user:
   php:

--- a/php/7.2/Dockerfile
+++ b/php/7.2/Dockerfile
@@ -23,8 +23,12 @@ RUN apt-get update -yqq && \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Insert the timezone and disable xdebug
+# Insert the timezone
+# Disable xdebug
+# Ensure PDF support is enabled in Image Magick
 RUN echo "date.timezone=UTC" > /usr/local/etc/php/conf.d/php_timezone.ini && \
-    mv /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini /usr/local/etc/php/conf.d/docker-php-ext-xdebug.disabled
+    mv /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini /usr/local/etc/php/conf.d/docker-php-ext-xdebug.disabled && \
+    sed -i -e '/rights="none" pattern="{PS,PDF,XPS}"/ s#<!--##g;s#-->##g;' /etc/ImageMagick-6/policy.xml && \
+    sed -i -e 's/rights="none" pattern="{PS,PDF,XPS}"/rights="read|write" pattern="PDF"/' /etc/ImageMagick-6/policy.xml
 
 USER $IMAGE_USER


### PR DESCRIPTION
Fixes #8 

Enable PDF support inside ImageMagick policy file. Adds Goss checks to ensure all builds have it enabled.