### PR TITLE
Use fully qualified tag for Docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,16 +15,24 @@ jobs:
       matrix:
         php: [8.1, 8.2]
     env:
-      IMAGE_VERSION: ${{ matrix.php }}
       NAMESPACE: 'klinktechnology/k-box-ci-pipeline-php'
       CI_COMMIT_SHORT_SHA: ${{github.sha}}
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 1
+    - name: Define image version
+      run: |
+        curl -sSLf https://github.com/keilerkonzept/dockerfile-json/releases/download/1.0.8/dockerfile-json_1.0.8_linux_x86_64.tar.gz -o ./dockerfile-json.tar.gz
+        tar -xvf ./dockerfile-json.tar.gz
+        chmod +x dockerfile-json
+        baseImage=$(./dockerfile-json php/${{ matrix.php }}/Dockerfile | jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName' | cut -c4-)
+        echo "IMAGE_VERSION=${baseImage#:}" >> $GITHUB_ENV
+        rm -f dockerfile-json*
     - name: Build the Docker image 
       run: |
-        docker pull php:$IMAGE_VERSION || true
-        docker pull $NAMESPACE:$IMAGE_VERSION || true
-        docker build --compress --cache-from $NAMESPACE:$IMAGE_VERSION --build-arg VCS_REF=$CI_COMMIT_SHORT_SHA --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') -t $NAMESPACE:$IMAGE_VERSION -f php/${{ matrix.php }}/Dockerfile .
+        docker pull $NAMESPACE:${{ matrix.php }} || true
+        docker build --compress --cache-from $NAMESPACE:${{ matrix.php }} --build-arg VCS_REF=$CI_COMMIT_SHORT_SHA --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') -t $NAMESPACE:$IMAGE_VERSION -f php/${{ matrix.php }}/Dockerfile .
     - name: Run Goss 
       run: |
         docker run -t --rm -v $(pwd):/var/www/html $NAMESPACE:$IMAGE_VERSION goss -g goss.yml v
@@ -37,4 +45,6 @@ jobs:
     - name: Push the Docker image
       if: github.event_name == 'push'
       run: |
+        docker tag $NAMESPACE:$IMAGE_VERSION $NAMESPACE:${{ matrix.php }}
         docker push $NAMESPACE:$IMAGE_VERSION
+        docker push $NAMESPACE:${{ matrix.php }}


### PR DESCRIPTION
Using `8.1` or `8.2` as tags for the produced images can have unintended side effects when upstream images include deep change or there is a need to revert.

In this pull I'm attempting at tagging the image based on the fully qualified tag of the PHP base image used. For example if the base image is `php:8.1.20-bullseye` the resulting image must be tagged as `8.1.20-bullseye` to overcome the above mentioned effects.

There are additional benefits:
1. Be able to revert quickly
2. Produce OS dependent images or variants
3. Have a reliable way to rollback to a previous version

Generic  `8.1`, `8.2` tags will remain and references the last build (hopefully with the latest version).